### PR TITLE
[BoardLikes] NotNull 마이그레이션 및 좋아요 시 게시글 좋아요 갯수 + 1

### DIFF
--- a/src/main/java/stanl_2/weshareyou/domain/board_like/aggregate/vo/request/BoardLikeRequestVO.java
+++ b/src/main/java/stanl_2/weshareyou/domain/board_like/aggregate/vo/request/BoardLikeRequestVO.java
@@ -1,15 +1,19 @@
 package stanl_2.weshareyou.domain.board_like.aggregate.vo.request;
 
-import lombok.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode
 public class BoardLikeRequestVO {
-    @NonNull
+    @NotNull(message = "게시판 ID를 입력하여 주세요.")
     private Long boardId;
 
-    @NonNull
+    @NotNull
     private Long memberId;
 }

--- a/src/main/java/stanl_2/weshareyou/domain/board_like/aggregate/vo/response/BoardLikeResponseVO.java
+++ b/src/main/java/stanl_2/weshareyou/domain/board_like/aggregate/vo/response/BoardLikeResponseVO.java
@@ -9,9 +9,9 @@ import lombok.*;
 @AllArgsConstructor
 @EqualsAndHashCode
 public class BoardLikeResponseVO {
-    @NonNull
+    @NotNull
     private Long boardId;
 
-    @NonNull
+    @NotNull
     private Long memberId;
 }


### PR DESCRIPTION
---
name: VO 및 좋아요 관련
about: NotNull 마이그레이션 및 좋아요 시 게시글 좋아요 갯수 +1
labels: enhancement, refactor
---
## 코드 변경 사유
- [x] 신규 기능 추가
- [x] 기존 기능 수정
- [ ] 버그 수정
## 관련 이슈 (버그 수정인 경우)
- (#14)
- (#15)
## 결과
![image](https://github.com/user-attachments/assets/9487ec00-e2c4-4de8-b2b5-4713c0d68960)
![image](https://github.com/user-attachments/assets/0ab5f6ea-36ab-410e-9bc1-5558f860f178)

--